### PR TITLE
adds secrets-store-csi-driver

### DIFF
--- a/stable/aurora-platform/charts/aurora-core/templates/secrets-store-csi-driver/_helpers.tpl
+++ b/stable/aurora-platform/charts/aurora-core/templates/secrets-store-csi-driver/_helpers.tpl
@@ -1,0 +1,50 @@
+{{/*
+The image section for the driver image.
+*/}}
+{{- define "driver.image" -}}
+{{- if (and .Values.components.secretsStoreCSIDriver.images.driver.registry .Values.components.secretsStoreCSIDriver.images.driver.image.repository) }}
+repository: "{{ .Values.components.secretsStoreCSIDriver.images.driver.image.registry }}/{{ .Values.components.secretsStoreCSIDriver.images.driver.image.repository }}"
+{{- else if .Values.components.secretsStoreCSIDriver.images.driver.image.repository }}
+repository: "{{ (default "registry.k8s.io" .Values.global.container.registry) }}/{{ .Values.components.secretsStoreCSIDriver.images.driver.image.repository }}"
+{{- end }}
+{{- if .Values.components.secretsStoreCSIDriver.images.driver.image.tag }}
+tag: {{ .Values.components.secretsStoreCSIDriver.images.driver.image.tag }}
+{{- end }}
+{{- if .Values.components.secretsStoreCSIDriver.images.driver.image.pullPolicy }}
+pullPolicy: {{ .Values.components.secretsStoreCSIDriver.images.driver.image.pullPolicy }}
+{{- end }}
+{{- end }}
+
+{{/*
+The image section for the CRDs image.
+*/}}
+{{- define "crds.image" -}}
+{{- if (and .Values.components.secretsStoreCSIDriver.images.crds.image.registry .Values.components.secretsStoreCSIDriver.images.crds.image.repository) }}
+repository: "{{ .Values.components.secretsStoreCSIDriver.images.crds.image.registry }}/{{ .Values.components.secretsStoreCSIDriver.images.crds.image.repository }}"
+{{- else if .Values.components.secretsStoreCSIDriver.images.crds.image.repository }}
+repository: "{{ (default "registry.k8s.io" .Values.global.container.registry) }}/{{ .Values.components.secretsStoreCSIDriver.images.crds.image.repository }}"
+{{- end }}
+{{- if .Values.components.secretsStoreCSIDriver.images.crds.image.tag }}
+tag: {{ .Values.components.secretsStoreCSIDriver.images.crds.image.tag }}
+{{- end }}
+{{- if .Values.components.secretsStoreCSIDriver.images.crds.image.pullPolicy }}
+pullPolicy: {{ .Values.components.secretsStoreCSIDriver.images.crds.image.pullPolicy }}
+{{- end }}
+{{- end }}
+
+{{/*
+The image section for the Registrar image.
+*/}}
+{{- define "registrar.image" -}}
+{{- if (and .Values.components.secretsStoreCSIDriver.images.registrar.image.registry .Values.components.secretsStoreCSIDriver.images.registrar.image.repository) }}
+repository: "{{ .Values.components.secretsStoreCSIDriver.images.registrar.image.registry }}/{{ .Values.components.secretsStoreCSIDriver.images.registrar.image.repository }}"
+{{- else if .Values.components.secretsStoreCSIDriver.images.registrar.image.repository }}
+repository: "{{ (default "registry.k8s.io" .Values.global.container.registry) }}/{{ .Values.components.secretsStoreCSIDriver.images.registrar.image.repository }}"
+{{- end }}
+{{- if .Values.components.secretsStoreCSIDriver.images.registrar.image.tag }}
+tag: {{ .Values.components.secretsStoreCSIDriver.images.registrar.image.tag }}
+{{- end }}
+{{- if .Values.components.secretsStoreCSIDriver.images.registrar.image.pullPolicy }}
+pullPolicy: {{ .Values.components.secretsStoreCSIDriver.images.registrar.image.pullPolicy }}
+{{- end }}
+{{- end }}

--- a/stable/aurora-platform/charts/aurora-core/templates/secrets-store-csi-driver/namespace.yaml
+++ b/stable/aurora-platform/charts/aurora-core/templates/secrets-store-csi-driver/namespace.yaml
@@ -1,0 +1,85 @@
+{{ if .Values.components.secretsStoreCSIDriver.enabled -}}
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: "{{ .Values.global.cluster }}-secrets-store-namespace"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: {{ .Values.global.project }}
+  source:
+    chart: {{ .Values.global.namespace.helm.chart }}
+    repoURL: {{ default .Values.global.helm.repository .Values.global.namespace.helm.repository }}
+    targetRevision: {{ .Values.global.namespace.helm.targetRevision }}
+    helm:
+      releaseName: secrets-store-csi-driver-system
+      values: |
+        # Information about the namespace.
+        information:
+          # Organisational information.
+          division: "Aurora"
+          team: "Aurora Solutions"
+          projectName: "Aurora Platform"
+          projectLead: "Albert Abdullah Kouri"
+          # The priority of the workload. Can be critical or medium.
+          priority: "medium"
+          technicalLead: "William Hearn"
+          # The Jira ticket ID of the Epic used to onboard the project.
+          onboardingEpic: "CN-1"
+          # The link to the authority to operate.
+          authorityToOperate: "https://gcdocs.gc.ca/ssc-spc/example"
+          # Information about tooling.
+          gitGroupURL: "https://github.com/gccloudone-aurora"
+          # Financial and organizational identifiers.
+          FRC: 0001
+          PE: 001
+          workloadID: 0000001
+          productID: 00001
+        # Configurations about the namespace.
+        namespace:
+        # Extra labels to add to the namespace.
+          labels: {}
+          # The type of namespace.
+          # Can be one of [gateway, solution, system].
+          type: "system"
+        # Policy configurations on the namespace.
+        policies:
+          # List of host/path that can be exposed from the namespace.
+          allowedHosts: []
+            # - www.example.ca/service
+            # - www.example.ca/
+            # - www.example.ca
+          # Boolean which defines if the namespace should have Istio injection.
+          # TODO: Needs to be set to true
+          istioInjection: false
+          # Refer to https://kubernetes.io/docs/concepts/security/pod-security-admission/
+          podSecurityAdmission:
+            enforce:
+              level: privileged
+        # Defines the access control on the namespace.
+        # Roles will be assigned based on the namespace type.
+        rbac:
+          groups: []
+        # Defines resource quotas on the namespace.
+        resourceQuotas:
+          # The maximum number of pods that can be in the namespace.
+          pods: 60
+          # Quotas related to services and external traffic.
+          services:
+            # The maximum number of loadbalancers that can be configured.
+            loadbalancers: 0
+            # The maximum number of NodePorts that can be configured.
+            nodeports: 0
+          # The upper limit of storage that can be requested across all persistent volumes.
+          # Expects a string value of a number with or without units (uses SI units).
+          storage: '0'
+  destination:
+    name: {{ .Values.global.cluster }}
+    namespace: platform-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+
+{{- end }}

--- a/stable/aurora-platform/charts/aurora-core/templates/secrets-store-csi-driver/secrets-store-csi-driver.yaml
+++ b/stable/aurora-platform/charts/aurora-core/templates/secrets-store-csi-driver/secrets-store-csi-driver.yaml
@@ -1,0 +1,58 @@
+{{ if .Values.components.secretsStoreCSIDriver.enabled -}}
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: "{{ .Values.global.cluster }}-secrets-store-csi-driver"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: {{ .Values.global.project }}
+  source:
+    chart: {{ default "secrets-store-csi-driver" .Values.components.secretsStoreCSIDriver.helm.chart }}
+    {{- if .Values.components.secretsStoreCSIDriver.helm.repository }}
+    repoURL: {{ .Values.components.secretsStoreCSIDriver.helm.repository }}
+    {{- else }}
+    repoURL: {{ default "https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts" .Values.global.helm.repository }}
+    {{- end }}
+    targetRevision: {{ default "1.5.4" .Values.components.secretsStoreCSIDriver.targetRevision }}
+    helm:
+      releaseName: secrets-store-csi-driver
+      values: |-
+        linux:
+          enabled: true
+
+          image: {{- default "{}" (include "driver.image" .) | nindent 12 }}
+
+          driver:
+            {{ if .Values.components.secretsStoreCSIDriver.resources -}}
+            resources: {{ toYaml .Values.components.secretsStoreCSIDriver.resources | nindent 14 }}
+            {{- end }}
+
+
+          crds:
+            enabled: true
+            image: {{- default "{}" (include "crds.image" .) | nindent 14 }}
+
+          registrarImage: {{- default "{}" (include "registrar.image" .) | nindent 12 }}
+            
+          priorityClassName: {{ .Values.components.secretsStoreCSIDriver.priorityClassName }}
+
+
+          {{ if .Values.components.secretsStoreCSIDriver.tolerations -}}
+          tolerations: {{ toYaml .Values.components.secretsStoreCSIDriver.tolerations | nindent 12 }}
+          {{- end }}
+
+        windows:
+          # not supported at the moment
+          enabled: false
+
+  destination:
+    name: {{ .Values.global.cluster }}
+    namespace: secrets-store-csi-driver-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+
+{{- end }}

--- a/stable/aurora-platform/charts/aurora-core/values.yaml
+++ b/stable/aurora-platform/charts/aurora-core/values.yaml
@@ -1945,6 +1945,52 @@ components:
       #  prodMajor: ""
       #  prodMinor: ""
 
+  secretsStoreCSIDriver:
+    enabled: false
+    helm: {}
+      # chart: secrets-store-csi-driver
+      # repository: https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
+      # targetRevision: 1.5.4
+  
+    images:
+      driver:
+        image:
+          # registry: registry.k8s.io
+          repository: csi-secrets-store/driver
+          # tag: "v1.5.4"
+          # pullPolicy: IfNotPresent
+
+      crds:
+        image:
+          # registry: registry.k8s.io
+          repository: csi-secrets-store/driver-crds
+          # tag: "v1.5.4"
+          # pullPolicy: IfNotPresent
+
+      registrar:
+        image:
+          # registry: registry.k8s.io
+          repository: sig-storage/csi-node-driver-registrar
+          tag: v2.13.0
+
+    tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+
+    resources: {}
+      # limits:
+      #   cpu: ""
+      #   memory: ""
+      # requests:
+      #   cpu: ""
+      #   memory: ""
+    
+    priorityClassName: platform-cluster-medium
+
   tetragon:
     enabled: false
 

--- a/stable/aurora-platform/values.yaml
+++ b/stable/aurora-platform/values.yaml
@@ -96,6 +96,7 @@ core:
     # ntp: {}
     # podtracker: {}
     # prometheus: {}
+    # secretsStoreCSIDriver: {}
     # tetragon: {}
     # trustManager: {}
     # vaultAgent: {}


### PR DESCRIPTION
This PR adds the secrets-store-csi-driver, which enables the use of a standard interface to CSP secrets engines.