### PR TITLE
feat(trust-manager): updates ca-certificates bundle key in ConfigMap

### DIFF
--- a/stable/aurora-platform/charts/aurora-core/templates/trust-manager/bundle.yaml
+++ b/stable/aurora-platform/charts/aurora-core/templates/trust-manager/bundle.yaml
@@ -36,7 +36,7 @@ spec:
                 {{ end }}
               target:
                 configMap:
-                  key: "custom.crt"
+                  key: "ca-certificates.crt"
                 namespaceSelector:
                   matchLabels:
                     namespace.ssc-spc.gc.ca/trust-manager: active


### PR DESCRIPTION
Since nothing is using it yet, I wanted to propose we make the filename/key for the ca-certificates bundle match what many containers will be expecting. This PR updates the name of the key in the ConfigMap from "custom.crt" to "ca-certificates.crt"