### PR TITLE
fix(trust-manager): uses quotation instead of multiline

### DIFF
--- a/stable/aurora-platform/charts/aurora-core/templates/trust-manager/bundle.yaml
+++ b/stable/aurora-platform/charts/aurora-core/templates/trust-manager/bundle.yaml
@@ -31,8 +31,7 @@ spec:
               sources:
                 - useDefaultCAs: true
                 {{ if .Values.components.trustManager.bundle.customCA }}
-                - inLine: |
-                    {{ .Values.components.trustManager.bundle.customCA }}
+                - inLine: {{ .Values.components.trustManager.bundle.customCA | quote }}
                 {{ end }}
               target:
                 configMap:


### PR DESCRIPTION
When passing the customCA as a multi-line string to the trust-manager part of the helm chart, it fails with an error.

Switching to quotes fixes this error, as the value is rendered as a single line with newline characters.

For example, without the use of quotes, a multiline value fails with the following error:

> Error: YAML parse error on aurora-platform/charts/core/templates/trust-manager/bundle.yaml: error converting YAML to JSON: yaml: line 35: could not find expected ':'

And after this change, it renders properly:

```yaml
- inLine: "-----BEGIN CERTIFICATE-----\n..."
```