### PR TITLE
feat(aurora-platform): upgrade Argo CD to v3.2

### DIFF
--- a/stable/argocd-instance/Chart.yaml
+++ b/stable/argocd-instance/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.3
+version: 0.11.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v2.14.21"
+appVersion: "v3.2.1"

--- a/stable/argocd-instance/values.yaml
+++ b/stable/argocd-instance/values.yaml
@@ -32,7 +32,7 @@ argocdInstance:
 
   image:
     name: "argoproj/argocd"
-    version: "v2.14.21"
+    version: "v3.2.1"
 
   nodeSelector: {}
   tolerations: []

--- a/stable/aurora-platform/Chart.yaml
+++ b/stable/aurora-platform/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.125
+version: 0.0.128
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/aurora-platform/charts/aurora-mgmt/templates/argo-foundation/argocd-instance.yaml
+++ b/stable/aurora-platform/charts/aurora-mgmt/templates/argo-foundation/argocd-instance.yaml
@@ -13,7 +13,7 @@ spec:
     {{- else }}
     repoURL: {{ default "https://gccloudone-aurora.github.io/aurora-platform-charts" .Values.global.helm.repository }}
     {{- end }}
-    targetRevision: {{ default "0.8.3" .Values.components.argoFoundation.argocdInstance.helm.targetRevision }}
+    targetRevision: {{ default "0.11.0" .Values.components.argoFoundation.argocdInstance.helm.targetRevision }}
     plugin:
       env:
         - name: HELM_RELEASE_NAME

--- a/stable/aurora-platform/charts/aurora-mgmt/templates/argo-solutions/argocd-instance.yaml
+++ b/stable/aurora-platform/charts/aurora-mgmt/templates/argo-solutions/argocd-instance.yaml
@@ -15,7 +15,7 @@ spec:
     {{- else }}
     repoURL: {{ default "https://gccloudone-aurora.github.io/aurora-platform-charts" .Values.global.helm.repository }}
     {{- end }}
-    targetRevision: {{ default "0.8.3" .Values.components.argoSolution.argocdInstance.helm.targetRevision }}
+    targetRevision: {{ default "0.11.0" .Values.components.argoSolution.argocdInstance.helm.targetRevision }}
     plugin:
       env:
         - name: HELM_RELEASE_NAME


### PR DESCRIPTION
### Analysis

I don't think any action is required. For example, we don't use sourceHydrator

### Changes

#### Hydration Paths
**Change:** You can no longer configure source hydration (manifest generation) to write to the repository root (. or /). Previous versions risking wiping out unrelated files (like README.md or CI configurations) because hydration cleans the target directory before writing.

**Action Required:** Audit your Applications. Any .spec.sourceHydrator.syncSource.path that is empty, missing, or set to . must be changed to a subdirectory (e.g., apps/guestbook).


#### CronJob Health Status Logic

**Change:** If a CronJob is suspended, its health status now defaults to Healthy. However, if you have active jobs running, the status might flip-flop between Healthy and Degraded more aggressively.

Customization: If you want suspended CronJobs to report as Suspended (instead of Healthy), you must manually configure resource.customizations.health.batch_CronJob in argocd-cm.

#### ApplicationSet Status Limit

**Change:** The list of resources in an ApplicationSet's status field is now capped at 5000 elements.

**Impact:** Prevents Etcd database bloat for massive ApplicationSets. If you have sets generating more than 5000 resources, the status list will be truncated. This limit is configurable via applicationsetcontroller.status.max.resources.count.