### PR TITLE
feat(aurora-platform): add velero workload identity change adjustments

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -344,10 +344,8 @@ core:
       volumeSnapshot:
         resourceGroupName: '<path:<FILLIN_ARGO_KV>#<FILLIN_ARGO_KV_PREFIX>-velero-sa-resource-group-name>'
 
-      aadPodIdentity:
-        azureManagedIdentity:
-          clientId: '<path:<FILLIN_ARGO_KV>#<FILLIN_ARGO_KV_PREFIX>-velero-aadpodidentity-client-id>'
-          resourceId: '<path:<FILLIN_ARGO_KV>#<FILLIN_ARGO_KV_PREFIX>-velero-aadpodidentity-resource-id>'
+      azureWorkloadIdentity:
+        clientId: '<path:<FILLIN_ARGO_KV>#<FILLIN_ARGO_KV_PREFIX>-velero-aadpodidentity-client-id>'
 
   rbac:
     platformOperator:

--- a/stable/aurora-platform/Chart.yaml
+++ b/stable/aurora-platform/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.131
+version: 0.0.132
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/aurora-platform/charts/aurora-core/templates/velero/netpol.yaml
+++ b/stable/aurora-platform/charts/aurora-core/templates/velero/netpol.yaml
@@ -50,24 +50,6 @@ spec:
                   app.kubernetes.io/name: velero
               policyTypes:
               - Egress
-          - apiVersion: networking.k8s.io/v1
-            kind: NetworkPolicy
-            metadata:
-              name: allow-egress-to-azureidentity-from-velero
-              namespace: velero-system
-            spec:
-              egress:
-              - ports:
-                - port: 80
-                  protocol: TCP
-                to:
-                - ipBlock:
-                    cidr: 169.254.169.254/32
-              podSelector:
-                matchLabels:
-                  app.kubernetes.io/name: velero
-              policyTypes:
-              - Egress
   destination:
     name: {{ .Values.global.cluster }}
     namespace: platform-system

--- a/stable/aurora-platform/charts/aurora-core/values.yaml
+++ b/stable/aurora-platform/charts/aurora-core/values.yaml
@@ -2215,7 +2215,7 @@ components:
                 app.kubernetes.io/instance: velero
     
     azureWorkloadIdentity:
-      enabled: false
+      enabled: true
       # clientId: ""
     
     serviceAccount:
@@ -2230,13 +2230,6 @@ components:
 
     volumeSnapshot: {}
       # resourceGroupName:
-
-    aadPodIdentity:
-      name: velero
-      enabled: true
-      azureManagedIdentity: {}
-        # clientId: ""
-        # resourceId: ""
 
     plugins:
       azure:


### PR DESCRIPTION
Some suggested changes for PR https://github.com/gccloudone-aurora/aurora-platform-charts/pull/85. If accepted, the changes will be merged in that branch

Changes:
- Remove the aad-pod-identity specific values from the values.yaml file
- Remove the aad-pod-identity specific network policy
- Change to use workload identity by default
- Modify the test config to reflect the change from aad pod identity to workload identity for Velero 

