### PR TITLE
add managed identity config for cluster issuer manifest

### DIFF
--- a/stable/aurora-platform/Chart.yaml
+++ b/stable/aurora-platform/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.140
+version: 0.0.141
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/aurora-platform/charts/aurora-core/templates/cert-manager/_helpers.tpl
+++ b/stable/aurora-platform/charts/aurora-core/templates/cert-manager/_helpers.tpl
@@ -91,6 +91,8 @@ The image section for Cert Manager Startup API Check.
 cnameStrategy: Follow
 azureDNS:
     hostedZoneName: {{ required "certManager.issuers.dns01.azure.zone is required" .Values.components.certManager.issuers.dns01.azure.zone }}
+    managedIdentity:
+        clientID: {{ required "certManager.azureWorkloadIdentity.clientId is required" .Values.components.certManager.azureWorkloadIdentity.clientId | quote }}
     resourceGroupName: {{ required "certManager.issuers.dns01.azure.resourceGroupName is required" .Values.components.certManager.issuers.dns01.azure.resourceGroupName }}
     subscriptionID: {{ required "certManager.issuers.dns01.azure.subscriptionId is required" .Values.components.certManager.issuers.dns01.azure.subscriptionId }}
 {{- else if eq .Values.global.provider "aws" }}


### PR DESCRIPTION
Ref: https://cert-manager.io/docs/configuration/acme/dns01/azuredns/#configure-a-clusterissuer

```
    solvers:
    - dns01:
        azureDNS:
          hostedZoneName: $AZURE_ZONE_NAME
          resourceGroupName: $AZURE_RESOURCE_GROUP
          subscriptionID: $AZURE_SUBSCRIPTION_ID
          environment: AzurePublicCloud
          **managedIdentity:**
            **clientID: $IDENTITY_CLIENT_ID**
```