### PR TITLE
fix(aurora-core): fluent-operator ignoring containerRuntime value

### DIFF
--- a/stable/aurora-platform/charts/aurora-core/templates/fluent-operator/operator.yaml
+++ b/stable/aurora-platform/charts/aurora-core/templates/fluent-operator/operator.yaml
@@ -19,6 +19,8 @@ spec:
     helm:
       releaseName: fluent-operator
       values: |
+        containerRuntime: {{ .Values.components.fluentOperator.containerRuntime | default "containerd" }}
+
         Kubernetes: true
 
         operator:


### PR DESCRIPTION
Fixes fluent-operator always being deployed for "docker" (a result of the Helm chart version) instead of utilizing the `containerRuntime` value.