### PR TITLE
[AUR-585] Istio - Upgrade API Version and Remove Conflicting Attributes

### DIFF
--- a/stable/aurora-platform/Chart.yaml
+++ b/stable/aurora-platform/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.0.171
+version: 0.0.172
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/istio-ingress-gateway/Chart.yaml
+++ b/stable/istio-ingress-gateway/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.7
+version: 0.0.8
 
 dependencies:
   - name: gateway

--- a/stable/istio-ingress-gateway/templates/gateway-https.yaml
+++ b/stable/istio-ingress-gateway/templates/gateway-https.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.https.enabled }}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: {{ include "istio-ingress-gateway.fullname" . }}-https
@@ -30,8 +30,6 @@ spec:
       maxProtocolVersion: TLSV1_2
       minProtocolVersion: TLSV1_2
       mode: SIMPLE
-      privateKey: sds
-      serverCertificate: sds
   {{- if .Values.additionalGatewayHosts }}
   {{- toYaml .Values.additionalGatewayHosts | nindent 2 }}
   {{- end }}


### PR DESCRIPTION
- Addresses below error:

` admission webhook "validation.istio.io" denied the request: configuration is invalid: only one of credential_name, credential_names, server_certificate/private_key, tls_certificates should be specified`