### PR TITLE
fix(trivy-operator) fixes the severities tracked by the Trivy Operator

### DIFF
--- a/stable/aurora-platform/charts/aurora-core/values.yaml
+++ b/stable/aurora-platform/charts/aurora-core/values.yaml
@@ -2154,8 +2154,8 @@ components:
       # -- excludeImages is comma separated glob patterns for excluding images from scanning.
       # Example: pattern: `k8s.gcr.io/*/*` will exclude image: `k8s.gcr.io/coredns/coredns:v1.8.0`.
       excludeImages: ""
-      
-    severity: "HIGH,CRITICAL"
+
+    severity: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
     server:
       resources:
         requests:


### PR DESCRIPTION
The Trivy Operator is deployed with Unknown, Low, and Medium severities disabled. These should not be disabled by default.