### PR TITLE
feat(workflow): auto bump chart.yaml version

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -1,0 +1,79 @@
+name: Bump Helm Chart Versions
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  bump-helm-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install yq
+        run: |
+          sudo wget https://github.com/mikefarah/yq/releases/download/v4.43.1/yq_linux_amd64 -O /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
+
+      - name: Bump Helm chart versions
+        id: bump
+        run: |
+          set -e
+          
+          WATCHED_DIRS=(
+            "stable/argocd-instance"
+            "stable/argocd-operator"
+            "stable/aurora-namespace"
+            "stable/aurora-platform"
+            "stable/aurora-solution"
+            "stable/istio-custom-responses"
+            "stable/istio-ingress-gateway"
+          )
+
+          CHANGED=false
+
+          for DIR in "${WATCHED_DIRS[@]}"; do
+            if git diff --name-only origin/main HEAD | grep -q "^${DIR}/"; then
+              CHART_FILE="${DIR}/Chart.yaml"
+              
+              CURRENT_VERSION=$(yq e '.version' "$CHART_FILE")
+              IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+              
+              case "$DIR" in
+                stable/argocd-instance)
+                  MINOR=$((MINOR+1))
+                  PATCH=0
+                  ;;
+                stable/aurora-platform|stable/aurora-solution)
+                  PATCH=$((PATCH+1))
+                  ;;
+                *)
+                  PATCH=$((PATCH+1))
+                  ;;
+              esac
+
+              NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+              
+              # Update Chart.yaml
+              yq e -i ".version = \"$NEW_VERSION\"" "$CHART_FILE"
+              echo "Updated $CHART_FILE: $CURRENT_VERSION -> $NEW_VERSION"
+              
+              CHANGED=true
+            fi
+          done
+
+          echo "changed=$CHANGED" >> $GITHUB_OUTPUT
+
+      - name: Commit version bumps
+        if: steps.bump.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add stable/*/Chart.yaml
+          git commit -m "ci: Auto bump Helm chart versions"
+          git push origin HEAD

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -15,10 +15,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install yq
+      - name: Install Dependencies
         run: |
-          sudo wget https://github.com/mikefarah/yq/releases/download/v4.43.1/yq_linux_amd64 -O /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          echo "Installing yq..."
+          curl -fsSL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o /usr/local/bin/yq
+          chmod +x /usr/local/bin/yq
 
       - name: Bump Helm chart versions
         id: bump
@@ -59,7 +60,6 @@ jobs:
 
               NEW_VERSION="$MAJOR.$MINOR.$PATCH"
               
-              # Update Chart.yaml
               yq e -i ".version = \"$NEW_VERSION\"" "$CHART_FILE"
               echo "Updated $CHART_FILE: $CURRENT_VERSION -> $NEW_VERSION"
               
@@ -75,5 +75,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add stable/*/Chart.yaml
-          git commit -m "ci: Auto bump Helm chart versions"
+          git commit -m "ci: Auto bump Chart.yaml"
           git push origin HEAD

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -1,30 +1,40 @@
 name: Bump Helm Chart Versions
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
-    branches:
-      - main
+    branches: [main]
+  push:
+    branches: [main]
 
 jobs:
-  bump-helm-versions:
+  helm-versioning:
     runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
 
-      - name: Install Dependencies
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install yq
         run: |
-          echo "Installing yq..."
           curl -fsSL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o /usr/local/bin/yq
           chmod +x /usr/local/bin/yq
 
-      - name: Bump Helm chart versions
+      - name: Set mode
+        id: context
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "mode=preview" >> $GITHUB_OUTPUT
+            git fetch origin ${{ github.base_ref }}
+            echo "diff=origin/${{ github.base_ref }} HEAD" >> $GITHUB_OUTPUT
+          else
+            echo "mode=apply" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run Helm Chart version logic
         id: bump
         run: |
-          set -e
+          MODE="${{ steps.context.outputs.mode }}"
           
           WATCHED_DIRS=(
             "stable/argocd-instance"
@@ -36,22 +46,33 @@ jobs:
             "stable/istio-ingress-gateway"
           )
 
+          OUTPUT="### 🚀 Helm Chart Version Preview\n"
           CHANGED=false
 
+          if [[ "$MODE" == "preview" ]]; then
+            CHANGED_FILES=$(git diff --name-only ${{ steps.context.outputs.diff }})
+          else
+            CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD)
+          fi
+
           for DIR in "${WATCHED_DIRS[@]}"; do
-            if git diff --name-only origin/main HEAD | grep -q "^${DIR}/"; then
+            if echo "$CHANGED_FILES" | grep -q "^${DIR}/"; then
+
+              # Skip if Chart.yaml manually edited
+              if echo "$CHANGED_FILES" | grep -q "^${DIR}/Chart.yaml$"; then
+                OUTPUT="$OUTPUT\n- \`$DIR\`: ⏭️ skipped (version was manually changed)"
+                continue
+              fi
+
               CHART_FILE="${DIR}/Chart.yaml"
-              
+
               CURRENT_VERSION=$(yq e '.version' "$CHART_FILE")
               IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
-              
+
               case "$DIR" in
                 stable/argocd-instance)
                   MINOR=$((MINOR+1))
                   PATCH=0
-                  ;;
-                stable/aurora-platform|stable/aurora-solution)
-                  PATCH=$((PATCH+1))
                   ;;
                 *)
                   PATCH=$((PATCH+1))
@@ -59,21 +80,72 @@ jobs:
               esac
 
               NEW_VERSION="$MAJOR.$MINOR.$PATCH"
-              
-              yq e -i ".version = \"$NEW_VERSION\"" "$CHART_FILE"
-              echo "Updated $CHART_FILE: $CURRENT_VERSION -> $NEW_VERSION"
-              
-              CHANGED=true
+              OUTPUT="$OUTPUT\n- \`$DIR\`: $CURRENT_VERSION → **$NEW_VERSION**"
+
+              if [[ "$MODE" == "apply" ]]; then
+                sed -i "s/^version: .*/version: $NEW_VERSION/" "$CHART_FILE"
+                CHANGED=true
+              fi
             fi
           done
 
+          if [ "$OUTPUT" = "### 🚀 Helm Chart Version Preview\n" ]; then
+            OUTPUT="$OUTPUT\n_No chart version changes detected._"
+          fi
+
+          echo "body<<EOF" >> $GITHUB_OUTPUT
+          echo -e "$OUTPUT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
           echo "changed=$CHANGED" >> $GITHUB_OUTPUT
 
-      - name: Commit version bumps
-        if: steps.bump.outputs.changed == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add stable/*/Chart.yaml
-          git commit -m "ci: Auto bump Chart.yaml"
-          git push origin HEAD
+      - name: Comment on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        env:
+          BODY: ${{ steps.bump.outputs.body }}
+        with:
+          script: |
+            const body = process.env.BODY;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const botComment = comments.find(comment =>
+              comment.user.type === 'Bot' &&
+              comment.body.includes('Helm Chart Version Preview')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body
+              });
+            }
+
+      - name: Create auto-bump PR
+        if: github.event_name == 'push' && steps.bump.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: "ci: Auto bump Chart.yaml versions"
+          branch: "auto-bump-${{ github.run_id }}"
+          title: "Auto bump Helm Chart version"
+          body: |
+            This PR bumps the version in the Chart.yaml
+
+            ${{ steps.bump.outputs.body }}
+          base: main
+          add-paths: |
+            stable/*/Chart.yaml

--- a/stable/aurora-platform/charts/aurora-core/templates/cilium/cilium.yaml
+++ b/stable/aurora-platform/charts/aurora-core/templates/cilium/cilium.yaml
@@ -15,7 +15,7 @@ spec:
     {{- else }}
     repoURL: {{ default "https://helm.cilium.io" .Values.global.helm.repository }}
     {{- end }}
-    targetRevision: {{ default "1.19.1" .Values.components.cilium.helm.targetRevision }}
+    targetRevision: {{ default "1.20.1" .Values.components.cilium.helm.targetRevision }}
     plugin:
       env:
         - name: HELM_RELEASE_NAME

--- a/stable/aurora-platform/charts/aurora-core/templates/cilium/cilium.yaml
+++ b/stable/aurora-platform/charts/aurora-core/templates/cilium/cilium.yaml
@@ -15,7 +15,7 @@ spec:
     {{- else }}
     repoURL: {{ default "https://helm.cilium.io" .Values.global.helm.repository }}
     {{- end }}
-    targetRevision: {{ default "1.20.1" .Values.components.cilium.helm.targetRevision }}
+    targetRevision: {{ default "1.19.1" .Values.components.cilium.helm.targetRevision }}
     plugin:
       env:
         - name: HELM_RELEASE_NAME


### PR DESCRIPTION
Closes https://github.com/gccloudone-aurora/roadmap/issues/60

## How this impacts your workflow:
- You will no longer need to update the Chart.yaml and can instead let the workflow handle it. It will create a PR to bump it for you. 
- There is a special case where you may still want to manually update the Chart.yaml
- If you are updating argocd-operator for instance, then you'll bump the Chart.yaml version for agocd-operator from say 0.0.12->0.0.13, you will then use this new version in the targetRevision within aurora-platform. You will then need to re-release aurora-platform chart from version 0.0.197->0.0198. In this case you may want to manually update argocd-operator in your PR but you can allow the workflow to auto update aurora-platform. This unique case is tested and can be seen below. 
- If you want to continue manually updating the Chart.yaml you are also able to continue doing that. 

## How this works:
- When you make a change to a chart, for example, update cilium image this will cause the workflow to create a comment on this PR to preview that the version for the aurora-platform Chart.yaml will be going from 0.0.197 -> 0.0.198
- Once this PR is completed, the workflow will automatically create a new PR, updating the Chart.yaml You will have to review this PR, approve it, and complete it. 
- If you make a manual change to the Chart.yaml version then the github workflow will ignore that chart.

## Current limitations:
- If you make ANY changes to a chart (excluding Chart.yaml) the bot will try to create a PR to bump the version. This also includes changes where _the Chart.yaml version does not need to be bumped_ for example changes to a comment on the values.yaml. 
- This limitation is addressed by being able to close the PR if the changes introduced by the bot are not necessary. 
## Example of it working:
- https://github.com/SajidDeo/aurora-platform-charts/pull/2 (making some change to a chart)
- https://github.com/SajidDeo/aurora-platform-charts/pull/3 (the automatic PR created to bump version)



