### PR TITLE
feat(netpol): Ignore CSP governed namespaces

### DIFF
--- a/stable/aurora-platform/Chart.yaml
+++ b/stable/aurora-platform/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.0.196
+version: 0.0.197
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/aurora-platform/charts/aurora-app/templates/istio/netpol.yaml
+++ b/stable/aurora-platform/charts/aurora-app/templates/istio/netpol.yaml
@@ -23,10 +23,8 @@ spec:
             spec:
               endpointSelector:
                 matchExpressions:
-                  - key: k8s:io.kubernetes.pod.namespace
-                    operator: NotIn
-                    values:
-                      - kube-system
+                  - key: k8s:io.cilium.k8s.namespace.labels.namespace.ssc-spc.gc.ca/purpose
+                    operator: DoesNotExist
               ingress:
                 - fromEndpoints:
                     - matchLabels:
@@ -39,10 +37,8 @@ spec:
             spec:
               endpointSelector:
                 matchExpressions:
-                  - key: k8s:io.kubernetes.pod.namespace
-                    operator: NotIn
-                    values:
-                      - kube-system
+                  - key: k8s:io.cilium.k8s.namespace.labels.namespace.ssc-spc.gc.ca/purpose
+                    operator: DoesNotExist
               ingress:
                 - fromEndpoints:
                     - matchLabels:
@@ -55,10 +51,8 @@ spec:
             spec:
               endpointSelector:
                 matchExpressions:
-                  - key: k8s:io.kubernetes.pod.namespace
-                    operator: NotIn
-                    values:
-                      - kube-system
+                  - key: k8s:io.cilium.k8s.namespace.labels.namespace.ssc-spc.gc.ca/purpose
+                    operator: DoesNotExist
               egress:
                 - toEndpoints:
                     - matchLabels:

--- a/stable/aurora-platform/charts/aurora-core/templates/global/netpol.yaml
+++ b/stable/aurora-platform/charts/aurora-core/templates/global/netpol.yaml
@@ -35,10 +35,8 @@ spec:
             spec:
               endpointSelector:
                 matchExpressions:
-                  - key: k8s:io.kubernetes.pod.namespace
-                    operator: NotIn
-                    values:
-                      - kube-system
+                  - key: k8s:io.cilium.k8s.namespace.labels.namespace.ssc-spc.gc.ca/purpose
+                    operator: DoesNotExist
               egress:
                 - toEndpoints:
                     - matchLabels:
@@ -73,10 +71,8 @@ spec:
             spec:
               endpointSelector:
                 matchExpressions:
-                  - key: k8s:io.kubernetes.pod.namespace
-                    operator: NotIn
-                    values:
-                      - kube-system
+                  - key: k8s:io.cilium.k8s.namespace.labels.namespace.ssc-spc.gc.ca/purpose
+                    operator: DoesNotExist
               ingress:
                 - fromEntities:
                   - remote-node


### PR DESCRIPTION
Typically right now we ignore kube-system for any of our network policies.

However this rule is not enough when sometimes depending on certain deployments where other CSP features such as Azure Policy are enabled.

Then additional namespaces would need to be ignored like gatekeeper-system.

This new syntax just ensures rules only happen on namespaces that we own.