### PR TITLE
Platform-40: Improvements to Trivy configuration

### DIFF
--- a/stable/aurora-platform/charts/aurora-core/templates/trivy-operator/trivy-operator.yaml
+++ b/stable/aurora-platform/charts/aurora-core/templates/trivy-operator/trivy-operator.yaml
@@ -42,6 +42,8 @@ spec:
             
             operator: {{ toYaml .Values.components.trivy.operator | nindent 14 }}
 
+            trivyOperator: {{ toYaml .Values.components.trivy.trivyOperator | nindent 14 }}
+
             serviceMonitor:
               enabled: {{ .Values.components.trivy.servicemonitor.enabled }} 
 

--- a/stable/aurora-platform/charts/aurora-core/templates/trivy-operator/trivy-operator.yaml
+++ b/stable/aurora-platform/charts/aurora-core/templates/trivy-operator/trivy-operator.yaml
@@ -52,6 +52,7 @@ spec:
               javaDbRegistry: {{ default "docker.io" .Values.global.container.registry }}
               severity: {{ .Values.components.trivy.severity }}
               storageClassName: default
+              ignoreUnfixed: {{ default "false" .Values.components.trivy.ignoreUnfixed }}
               server: {{ toYaml .Values.components.trivy.server | nindent 16 }}
 
   destination:

--- a/stable/aurora-platform/charts/aurora-core/values.yaml
+++ b/stable/aurora-platform/charts/aurora-core/values.yaml
@@ -2273,19 +2273,24 @@ components:
     servicemonitor:
       enabled: true
 
+    # Ignore vulnerabilties where no fix is currently available (as there's no way to action on them)
+    ignoreUnfixed: true
     operator:
       # enable builtin server mode
       builtInTrivyServer: true
+      # Disable Trivy from using global secrets/service accounts to improve security
+      accessGlobalSecretsAndServiceaccount: false
       # -- the flag to enable vulnerability scanner
       vulnerabilityScannerEnabled: true
       # -- configAuditScannerEnabled the flag to enable configuration audit scanner
-      configAuditScannerEnabled: false
+      configAuditScannerEnabled: true
       # -- rbacAssessmentScannerEnabled the flag to enable rbac assessment scanner
-      rbacAssessmentScannerEnabled: false
+      rbacAssessmentScannerEnabled: true
       # -- infraAssessmentScannerEnabled the flag to enable infra assessment scanner
       infraAssessmentScannerEnabled: false
       # -- exposedSecretScannerEnabled the flag to enable exposed secret scanner
-      exposedSecretScannerEnabled: false
+      exposedSecretScannerEnabled: true
+      
       # -- excludeImages is comma separated glob patterns for excluding images from scanning.
       # Example: pattern: `k8s.gcr.io/*/*` will exclude image: `k8s.gcr.io/coredns/coredns:v1.8.0`.
       excludeImages: ""
@@ -2294,7 +2299,28 @@ components:
         seccompProfile:
           type: RuntimeDefault
 
-    severity: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
+    # Configuration of the trivy job
+    trivyOperator:
+      # Avoid mounting service tokens when scanning
+      scanJobAutomountServiceAccountToken: false
+      # Clean up scan jobs after completion to reduce job history bloat
+      scanJobTTL: "1h"
+      # Annotations to stop istio sidecar and to ensure autoscaling can evict
+      scanJobAnnotations:
+        sidecar.istio.io/inject: "false"
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      # Adding labels to job for simpler querying on status
+      scanJobPodTemplateLabels:
+        app.kubernetes.io/name: trivy-scan-job
+        app.kubernetes.io/managed-by: trivy-operator
+      # Only run on system nodes
+      scanJobNodeSelector:
+        node.ssc-spc.gc.ca/purpose: system
+      scanJobTolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+
+    severity: "MEDIUM,HIGH,CRITICAL"
     server:
       podSecurityContext:
         seccompProfile:

--- a/stable/aurora-platform/charts/aurora-core/values.yaml
+++ b/stable/aurora-platform/charts/aurora-core/values.yaml
@@ -2320,7 +2320,7 @@ components:
         - key: CriticalAddonsOnly
           operator: Exists
 
-    severity: "MEDIUM,HIGH,CRITICAL"
+    severity: "HIGH,CRITICAL"
     server:
       podSecurityContext:
         seccompProfile:


### PR DESCRIPTION
Made updates to Trivy to enable additional alerting signals and focus in on important signals (medium and higher, and only actionable items).

Also updated the configuration of the trivy job itself to improve it from an operational perspective so it avoids using secrets/tokens unnecessarily, avoids the istio sidecar, runs on system nodes only, adds additional job labels, and cleans up past job runs. 

This is connected to the following task: https://github.com/gccloudone-aurora/platform-services/issues/40