### PR TITLE
Platform-39: Enhancing kube-state-metrics

### DIFF
--- a/stable/aurora-platform/charts/aurora-core/templates/prometheus/operator.yaml
+++ b/stable/aurora-platform/charts/aurora-core/templates/prometheus/operator.yaml
@@ -287,10 +287,12 @@ spec:
               tolerations: {{ toYaml .Values.components.prometheus.kubeStateMetrics.tolerations | nindent 16 }}
               affinity: {{ toYaml .Values.components.prometheus.kubeStateMetrics.affinity | nindent 16 }}
 
+              ## This enables specific labels in Kubernetes to be used in Prometheus for grouping, as default behaviour is to strip away all labels
               metricLabelsAllowlist:
                 - nodes=[agentpool]
                 - namespaces=[namespace.ssc-spc.gc.ca/purpose]
               
+              ## Defines which resource types kube-state-metrics should be monitoring 
               collectors:
                 - pods
                 - deployments
@@ -306,6 +308,7 @@ spec:
                 - horizontalpodautoscalers
                 - ingresses
               
+              ## Release label is required so Prometheus Operator can scrape kube-state-metrics
               releaseLabel: true
               prometheus:
                 monitor:

--- a/stable/aurora-platform/charts/aurora-core/templates/prometheus/operator.yaml
+++ b/stable/aurora-platform/charts/aurora-core/templates/prometheus/operator.yaml
@@ -289,6 +289,29 @@ spec:
 
               metricLabelsAllowlist:
                 - nodes=[agentpool]
+                - namespaces=[namespace.ssc-spc.gc.ca/purpose]
+              
+              collectors:
+                - pods
+                - deployments
+                - nodes
+                - namespaces
+                - replicasets
+                - statefulsets
+                - daemonsets
+                - jobs
+                - cronjobs
+                - persistentvolumeclaims
+                - resourcequotas
+                - horizontalpodautoscalers
+                - ingresses
+              
+              releaseLabel: true
+              prometheus:
+                monitor:
+                  enabled: true
+                  honorLabels: true
+                  interval: 30s
 
             prometheus-node-exporter:
               image: {{ default "{}" (include "prometheus.prometheusNodeExporter.image" .) | nindent 16 }}

--- a/stable/aurora-platform/charts/aurora-core/values.yaml
+++ b/stable/aurora-platform/charts/aurora-core/values.yaml
@@ -1953,6 +1953,7 @@ components:
       #   password: ""
 
     kubeStateMetrics:
+      enabled: true
       image:
         # registry: registry.k8s.io
         repository: kube-state-metrics/kube-state-metrics


### PR DESCRIPTION
This PR is to enhance kube-state-metrics with additional functionality to pull from specific resources and monitor specific labels. Also explicitly enabled the feature in prometheus.

This is connected to the following task: https://github.com/gccloudone-aurora/platform-services/issues/39