### PR TITLE
platform-49-loki-netpol-change

### DIFF
--- a/stable/aurora-platform/charts/aurora-core/templates/fluent-operator/netpol.yaml
+++ b/stable/aurora-platform/charts/aurora-core/templates/fluent-operator/netpol.yaml
@@ -81,7 +81,7 @@ spec:
                     to:
                     - namespaceSelector:
                         matchLabels:
-                          kubernetes.io/metadata.name: loki
+                          kubernetes.io/metadata.name: loki-system
                       podSelector:
                         matchLabels:
                           app.kubernetes.io/component: gateway

--- a/stable/aurora-platform/charts/aurora-core/templates/kubernetes-event-exporter/netpol.yaml
+++ b/stable/aurora-platform/charts/aurora-core/templates/kubernetes-event-exporter/netpol.yaml
@@ -66,7 +66,7 @@ spec:
                 to:
                 - namespaceSelector:
                     matchLabels:
-                      kubernetes.io/metadata.name: loki
+                      kubernetes.io/metadata.name: loki-system
                   podSelector:
                     matchLabels:
                       app.kubernetes.io/component: gateway

--- a/stable/aurora-platform/charts/aurora-core/templates/prometheus/netpol.yaml
+++ b/stable/aurora-platform/charts/aurora-core/templates/prometheus/netpol.yaml
@@ -647,7 +647,7 @@ spec:
                     to:
                     - namespaceSelector:
                         matchLabels:
-                          kubernetes.io/metadata.name: loki
+                          kubernetes.io/metadata.name: loki-system
                       podSelector:
                         matchLabels:
                           app.kubernetes.io/component: gateway


### PR DESCRIPTION
Small fix to update the target namespace for network policies to work with the proper loki namespace name.