### PR TITLE
feat(strimzi): Add Strimzi Kafka Operator

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -593,6 +593,12 @@ app:
     solr:
       enabled: false
 
+    ###############
+    ### Strimzi ###
+    ###############
+    strimzi:
+      enabled: false
+
 ############
 ### MGMT ###
 ############

--- a/stable/aurora-platform/Chart.yaml
+++ b/stable/aurora-platform/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.0.228
+version: 0.0.229
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/aurora-platform/Chart.yaml
+++ b/stable/aurora-platform/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.0.334
+version: 0.0.234
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/aurora-platform/charts/aurora-app/templates/strimzi/_helpers.tpl
+++ b/stable/aurora-platform/charts/aurora-app/templates/strimzi/_helpers.tpl
@@ -1,0 +1,20 @@
+{{/*
+The image section for Strimzi Kafka Operator.
+*/}}
+{{- define "strimzi.image" -}}
+{{- if .Values.components.strimzi.image.registry }}
+registry: {{ default .Values.components.strimzi.image.registry .Values.global.container.registry }}
+{{- end }}
+{{- if .Values.components.strimzi.image.repository }}
+repository: {{ .Values.components.strimzi.image.repository }}
+{{- end }}
+{{- if .Values.components.strimzi.image.name }}
+name: {{ .Values.components.strimzi.image.name }}
+{{- end }}
+{{- if .Values.components.strimzi.image.tag }}
+tag: {{ .Values.components.strimzi.image.tag }}(default "quay.io" .Values.global.container.registry)
+{{- end }}
+{{- if .Values.components.strimzi.image.pullPolicy }}
+pullPolicy: {{ .Values.components.strimzi.image.pullPolicy }}
+{{- end }}
+{{- end }}

--- a/stable/aurora-platform/charts/aurora-app/templates/strimzi/namespace.yaml
+++ b/stable/aurora-platform/charts/aurora-app/templates/strimzi/namespace.yaml
@@ -1,0 +1,93 @@
+{{ if .Values.components.strimzi.enabled -}}
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: "{{ .Values.global.cluster }}-strimzi-namespace"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: {{ .Values.global.project }}
+  source:
+    chart: {{ .Values.global.namespace.helm.chart }}
+    repoURL: {{ default .Values.global.helm.repository .Values.global.namespace.helm.repository }}
+    targetRevision: {{ .Values.global.namespace.helm.targetRevision }}
+    helm:
+      releaseName: strimzi-system
+      values: |
+        # Information about the namespace.
+        information:
+          # Organisational information.
+          division: "Aurora"
+          team: "Aurora Solutions"
+          projectName: "Aurora Platform"
+          projectLead: "Albert Abdullah Kouri"
+          # The priority of the workload. Can be critical or medium.
+          priority: "medium"
+          technicalLead: "William Hearn"
+          # The Jira ticket ID of the Epic used to onboard the project.
+          onboardingEpic: "CN-1"
+          # The link to the authority to operate.
+          authorityToOperate: "https://gcdocs.gc.ca/ssc-spc/example"
+
+          # Information about tooling.
+          gitGroupURL: "https://github.com/gccloudone-aurora"
+
+          # Financial and organizational identifiers.
+          FRC: 0001
+          PE: 001
+          workloadID: 0000001
+          productID: 00001
+
+        # Configurations about the namespace.
+        namespace:
+        # Extra labels to add to the namespace.
+          labels: {}
+
+          # The type of namespace.
+          # Can be one of [gateway, solution, system].
+          type: "system"
+
+        # Policy configurations on the namespace.
+        policies:
+          # List of host/path that can be exposed from the namespace.
+          allowedHosts: []
+
+          # Configure the data plane mode for Istio.
+          # "sidecar" Enables sidecar injection (istio-injection=enabled).
+          # "ambient" Enables Ambient Mesh (istio.io/dataplane-mode=ambient).
+          istioMode: "ambient"
+
+          # Refer to https://kubernetes.io/docs/concepts/security/pod-security-admission/
+          podSecurityAdmission:
+            enforce:
+              level: privileged
+              version: v1.35
+
+        # Defines the access control on the namespace.
+        # Roles will be assigned based on the namespace type.
+        rbac:
+          groups: {{ toYaml .Values.rbac.platformOperator.groups | nindent 12 }}
+
+        # Defines resource quotas on the namespace.
+        resourceQuotas:
+          # The maximum number of pods that can be in the namespace.
+          pods: 60
+          # Quotas related to services and external traffic.
+          services:
+            # The maximum number of loadbalancers that can be configured.
+            loadbalancers: 0
+            # The maximum number of NodePorts that can be configured.
+            nodeports: 0
+          # The upper limit of storage that can be requested across all persistent volumes.
+          # Expects a string value of a number with or without units (uses SI units).
+          storage: '0'
+  destination:
+    name: {{ .Values.global.cluster }}
+    namespace: platform-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+
+{{- end }}

--- a/stable/aurora-platform/charts/aurora-app/templates/strimzi/netpol.yaml
+++ b/stable/aurora-platform/charts/aurora-app/templates/strimzi/netpol.yaml
@@ -1,0 +1,74 @@
+{{ if .Values.components.strimzi.enabled -}}
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: "{{ .Values.global.cluster }}-strimzi-netpol"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: {{ .Values.global.project }}
+  source:
+    chart: {{ .Values.global.raw.helm.chart }}
+    repoURL: {{ default .Values.global.helm.repository .Values.global.raw.helm.repository }}
+    targetRevision: {{ .Values.global.raw.helm.targetRevision }}
+    helm:
+      releaseName: strimzi-netpol
+      values: |
+        resources:
+          - apiVersion: cilium.io/v2
+            kind: CiliumClusterwideNetworkPolicy
+            metadata:
+              name: allow-ingress-from-strimzi-to-strimzi-instances
+            spec:
+              endpointSelector:
+                matchExpressions:
+                  - key: k8s:strimzi.io/kind
+                    operator: Exists
+              ingress:
+                - fromEndpoints:
+                    - matchLabels:
+                        k8s:io.kubernetes.pod.namespace: strimzi-system
+          - apiVersion: networking.k8s.io/v1
+            kind: NetworkPolicy
+            metadata:
+              name: allow-same-namespace
+              namespace: strimzi-system
+            spec:
+              podSelector: {}
+              policyTypes:
+                - Ingress
+                - Egress
+              ingress:
+                - from:
+                  - podSelector: {}
+              egress:
+                - to:
+                  - podSelector: {}
+          - apiVersion: networking.k8s.io/v1
+            kind: NetworkPolicy
+            metadata:
+              name: allow-egress-to-strimzi-instances-from-strimzi
+              namespace: strimzi-system
+            spec:
+              egress:
+              - to:
+                - namespaceSelector:
+                    matchLabels: {}
+                  podSelector:
+                    matchExpressions:
+                      - key: strimzi.io/kind
+                        operator: Exists
+              podSelector:
+                matchLabels: {}
+              policyTypes:
+              - Egress
+  destination:
+    name: {{ .Values.global.cluster }}
+    namespace: platform-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+
+{{- end }}

--- a/stable/aurora-platform/charts/aurora-app/templates/strimzi/rbac.yaml
+++ b/stable/aurora-platform/charts/aurora-app/templates/strimzi/rbac.yaml
@@ -1,0 +1,58 @@
+{{ if .Values.components.strimzi.enabled -}}
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: "{{ .Values.global.cluster }}-strimzi-rbac"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: {{ .Values.global.project }}
+  source:
+    chart: {{ .Values.global.raw.helm.chart }}
+    repoURL: {{ default .Values.global.helm.repository .Values.global.raw.helm.repository }}
+    targetRevision: {{ .Values.global.raw.helm.targetRevision }}
+    helm:
+      releaseName: strimzi-rbac
+      values: |
+        resources:
+          - apiVersion: rbac.authorization.k8s.io/v1
+            kind: ClusterRole
+            metadata:
+              name: strimzi-view-all
+              annotations:
+                kubernetes.io/description: "Allows viewing of all of the strimzi CRDs."
+              labels:
+                rbac.ssc-spc.gc.ca/aggregate-to-platform-operator-view: "true"
+                app.kubernetes.io/name: "solr-rbac"
+                app.kubernetes.io/instance: "{{ .Values.global.cluster }}"
+                app.kubernetes.io/part-of: platform-operator-rbac
+                app.kubernetes.io/managed-by: argo
+                helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version }}
+            rules:
+              - apiGroups:
+                  - kafkas.kafka.strimzi.io
+                  - kafkaconnects.kafka.strimzi.io
+                  - strimzipodsets.core.strimzi.io
+                  - kafkatopics.kafka.strimzi.io
+                  - kafkausers.kafka.strimzi.io
+                  - kafkanodepools.kafka.strimzi.io
+                  - kafkabridges.kafka.strimzi.io
+                  - kafkaconnectors.kafka.strimzi.io
+                  - kafkamirrormaker2s.kafka.strimzi.io
+                  - kafkarebalances.kafka.strimzi.io
+                resources:
+                  - '*'
+                verbs:
+                  - get
+                  - list
+                  - watch
+  destination:
+    name: {{ .Values.global.cluster }}
+    namespace: platform-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+
+{{- end }}

--- a/stable/aurora-platform/charts/aurora-app/templates/strimzi/strimzi.yaml
+++ b/stable/aurora-platform/charts/aurora-app/templates/strimzi/strimzi.yaml
@@ -1,0 +1,51 @@
+{{ if .Values.components.strimzi.enabled -}}
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: "{{ .Values.global.cluster }}-strimzi-operator"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: {{ .Values.global.project }}
+  source:
+    chart: {{ default "strimzi-kafka-operator" .Values.components.strimzi.helm.chart }}
+    {{- if .Values.components.strimzi.helm.repository }}
+    repoURL: {{ .Values.components.strimzi.helm.repository }}
+    {{- else }}
+    repoURL: {{ default "oci://quay.io/strimzi-helm/strimzi-kafka-operator" .Values.global.helm.repository }}
+    {{- end }}
+    targetRevision: {{ default "1.0.0" .Values.components.strimzi.helm.targetRevision }}
+    helm:
+      releaseName: strimzi-kafka-operator
+      values: |
+        image: {{ default "{}" (include "strimzi.image" .) | nindent 10 }}
+
+        defaultImageRegistry: {{ .Values.components.strimzi.defaultImageRegistry }}
+        defaultImageRepository: {{ .Values.components.strimzi.defaultImageRepository }}
+
+        replicas: {{ .Values.components.strimzi.replicas }}
+        resources: {{ toYaml .Values.components.strimzi.resources | nindent 10 }}
+
+        nodeSelector: {{ toYaml .Values.components.strimzi.nodeSelector | nindent 10 }}
+        tolerations: {{ toYaml .Values.components.strimzi.tolerations | nindent 10 }}
+        affinity: {{ toYaml .Values.components.strimzi.affinity | nindent 10 }}
+
+        watchNamespaces: []
+        watchAnyNamespace: true
+
+        rbac:
+          create: yes
+
+        serviceAccountCreate: true
+
+        priorityClassName: {{ .Values.components.strimzi.priorityClassName }}
+  destination:
+    name: {{ .Values.global.cluster }}
+    namespace: strimzi-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+
+{{- end }}

--- a/stable/aurora-platform/charts/aurora-app/values.yaml
+++ b/stable/aurora-platform/charts/aurora-app/values.yaml
@@ -590,7 +590,7 @@ components:
       repository: gccloudone-aurora/sidecar-terminator
       # tag: "main"
       # pullPolicy: IfNotPresent
-      
+
     podSecurityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -715,5 +715,53 @@ components:
               labelSelector:
                 matchLabels:
                   technology: zookeeper
+
+    priorityClassName: platform-cluster-medium
+
+  ###############
+  ### Strimzi ###
+  ###############
+  strimzi:
+    enabled: false
+
+    helm: {}
+      # chart: strimzi-kafka-operator
+      # repository: oci://quay.io/strimzi-helm/strimzi-kafka-operator
+      # targetRevision: 1.0.0
+
+    imagePullSecrets: []
+    image:
+      # registry: quay.io
+      repository: strimzi
+      name: operator
+      # tag: 1.0.0
+      # pullPolicy: IfNotPresent
+
+    defaultImageRegistry: quay.io
+    defaultImageRepository: strimzi
+
+    replicas: 1
+    resources: {}
+      # limits:
+      #   cpu: ""
+      #   memory: ""
+      # requests:
+      #   cpu: ""
+      #   memory: ""
+    nodeSelector:
+      kubernetes.io/os: linux
+      node.ssc-spc.gc.ca/purpose: system
+    tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          podAffinityTerm:
+            topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels:
+                app: strimzi
 
     priorityClassName: platform-cluster-medium

--- a/stable/aurora-platform/values.yaml
+++ b/stable/aurora-platform/values.yaml
@@ -124,6 +124,7 @@ app:
     # kiali: {}
     # sidecarTerminator: {}
     # solr: {}
+    # strimzi: {}
 
 ############
 ### MGMT ###


### PR DESCRIPTION
This adds Strimzi as a governed optional component coming from consultations with DND where Kafka is near ubiqutious in all of their clusters.

Strimzi is an incubated component from CNCF.

Architecturally it aligns with Aurora well given:

- Event-driven architectures are increasingly important for AI / ML pipelines, telemetry, mission systems, and disconnected / edge synchronization