### PR TITLE
feat(trivy): Updates to support restricted pss

### DIFF
--- a/stable/aurora-platform/charts/aurora-core/values.yaml
+++ b/stable/aurora-platform/charts/aurora-core/values.yaml
@@ -2320,10 +2320,22 @@ components:
       scanJobTolerations:
         - key: CriticalAddonsOnly
           operator: Exists
+      scanJobPodTemplatePodSecurityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      scanJobPodTemplateContainerSecurityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
 
     severity: "HIGH,CRITICAL"
     server:
       podSecurityContext:
+        runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
       securityContext:


### PR DESCRIPTION
Trivy is running into issues with its scan jobs due to the PSS restrictions. This update changes the settings so it runs in accordance to the restricted profile.

Here's the error for additional context:
<img width="1191" height="64" alt="image" src="https://github.com/user-attachments/assets/4262f2bd-8468-4c44-af6e-e4fa6271e7c8" />
