### PR TITLE
fix(trivy): setting UID to stop root/nonroot mismatch on scan jobs

### DIFF
--- a/stable/aurora-platform/Chart.yaml
+++ b/stable/aurora-platform/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.0.230
+version: 0.0.231
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/aurora-platform/charts/aurora-core/values.yaml
+++ b/stable/aurora-platform/charts/aurora-core/values.yaml
@@ -2307,7 +2307,7 @@ components:
       # Avoid mounting service tokens when scanning
       scanJobAutomountServiceAccountToken: false
       # Annotations to stop istio sidecar and to ensure autoscaling can evict
-      scanJobAnnotations: "sidecar.istio.io/inject=false,cluster-autoscaler.kubernetes.io/safe-to-evict=true"
+      scanJobAnnotations: "sidecar.istio.io/inject=false,cluster-autoscaler.kubernetes.io/safe-to-evict=true,fluent.sidecar.io/inject=false"
       # Adding labels to job for simpler querying on status
       scanJobPodTemplateLabels: "app.kubernetes.io/name=trivy-scan-job,app.kubernetes.io/managed-by=trivy-operator"
       # Only run on system nodes
@@ -2318,6 +2318,9 @@ components:
           operator: Exists
       scanJobPodTemplatePodSecurityContext:
         runAsNonRoot: true
+        runAsUser: 10000
+        runAsGroup: 10000
+        fsGroup: 10000
         seccompProfile:
           type: RuntimeDefault
       scanJobPodTemplateContainerSecurityContext:
@@ -2327,6 +2330,7 @@ components:
             - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
+        runAsUser: 10000
 
     severity: "HIGH,CRITICAL"
     server:


### PR DESCRIPTION
UID has to be added to avoid the scan jobs from failing due to root/nonroot mismatch. 

Also added in another annotation to stop fluent from logging this since it's a ephemeral job.