### PR TITLE
fix(trivy): Scan job cert mounting

### DIFF
--- a/stable/aurora-platform/Chart.yaml
+++ b/stable/aurora-platform/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.0.235
+version: 0.0.236
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/aurora-platform/charts/aurora-core/values.yaml
+++ b/stable/aurora-platform/charts/aurora-core/values.yaml
@@ -2247,7 +2247,7 @@ components:
         memory: 100M
       limits:
         cpu: 500m
-        memory: 500M
+        memory: 2Gi
     nodeSelector:
       kubernetes.io/os: linux
       node.ssc-spc.gc.ca/purpose: system
@@ -2328,6 +2328,15 @@ components:
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 10000
+      scanJobCustomVolumeMounts: 
+       - name: trust-manager-propagated-custom-ca
+         mountPath: /etc/ssl/certs/ca-certificates.crt
+         subPath: ca-certificates.crt
+         readOnly: true
+      scanJobCustomVolumes: 
+       - name: trust-manager-propagated-custom-ca
+         configMap:
+           name: trust-manager-propagated-custom-ca
 
     severity: "HIGH,CRITICAL"
     server:
@@ -2352,7 +2361,7 @@ components:
       extraServerVolumes:
         volumeMounts: 
          - name: trust-manager-propagated-custom-ca
-           mountPath: /etc/ssl/certs/trust-manager-propagated-custom-ca.crt
+           mountPath: /etc/ssl/certs/ca-certificates.crt
            subPath: ca-certificates.crt
            readOnly: true
         volumes: 

--- a/stable/aurora-platform/charts/aurora-core/values.yaml
+++ b/stable/aurora-platform/charts/aurora-core/values.yaml
@@ -2328,12 +2328,12 @@ components:
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 10000
-      scanJobCustomVolumeMounts: 
+      scanJobCustomVolumesMount: 
        - name: trust-manager-propagated-custom-ca
          mountPath: /etc/ssl/certs/ca-certificates.crt
          subPath: ca-certificates.crt
          readOnly: true
-      scanJobCustomVolumes: 
+      scanJobCustomVolumes:
        - name: trust-manager-propagated-custom-ca
          configMap:
            name: trust-manager-propagated-custom-ca


### PR DESCRIPTION
This PR fixes the attachment of the certificate for the FW so Trivy can scan against Docker and other hosted images.

It also increases the memory limits for the pod as there are consistent OOM errors when trying to scan the custom argocd-repo-server image located here: https://github.com/gccloudone-aurora/argocd-repo-server/pkgs/container/argocd-repo-server/748317255?tag=main