### PR TITLE
fix(trivy): Fixing setup of scan job pod resources

### DIFF
--- a/stable/aurora-platform/Chart.yaml
+++ b/stable/aurora-platform/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.0.240
+version: 0.0.241
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/aurora-platform/charts/aurora-core/templates/trivy-operator/trivy-operator.yaml
+++ b/stable/aurora-platform/charts/aurora-core/templates/trivy-operator/trivy-operator.yaml
@@ -52,6 +52,7 @@ spec:
               javaDbRegistry: {{ default "docker.io" .Values.global.container.registry }}
               severity: {{ .Values.components.trivy.severity }}
               storageClassName: default
+              resources: {{ toYaml .Values.components.trivy.scanJobResources | nindent 16 }}
               ignoreUnfixed: {{ default "false" .Values.components.trivy.ignoreUnfixed }}
               server: {{ toYaml .Values.components.trivy.server | nindent 16 }}
 

--- a/stable/aurora-platform/charts/aurora-core/values.yaml
+++ b/stable/aurora-platform/charts/aurora-core/values.yaml
@@ -2247,7 +2247,7 @@ components:
         memory: 100M
       limits:
         cpu: 500m
-        memory: 2Gi
+        memory: 500M
     nodeSelector:
       kubernetes.io/os: linux
       node.ssc-spc.gc.ca/purpose: system
@@ -2338,6 +2338,14 @@ components:
          configMap:
            name: trust-manager-propagated-custom-ca
 
+    scanJobResources:
+      requests:
+        cpu: 100m
+        memory: 100M
+      limits:
+        cpu: 500m
+        memory: 2Gi
+    
     severity: "HIGH,CRITICAL"
     server:
       podSecurityContext:


### PR DESCRIPTION
This PR resolves the configuration of resources for scan pod jobs. This is done to help resolve an OOM error when one of the underlying custom images are scanned on the management cluster.