### PR TITLE
feature(loki): Adding support for additonal Loki auth methods

### DIFF
--- a/stable/aurora-platform/Chart.yaml
+++ b/stable/aurora-platform/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.0.241
+version: 0.0.242
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/aurora-platform/charts/aurora-mgmt/templates/loki/loki.yaml
+++ b/stable/aurora-platform/charts/aurora-mgmt/templates/loki/loki.yaml
@@ -60,8 +60,14 @@ spec:
                       - loki.{{ .Values.global.ingressDomain }}
               basicAuth:
                 enabled: true
+                {{- if .Values.components.loki.basicAuth.existingSecret }}
+                existingSecret: {{ .Values.components.loki.basicAuth.existingSecret | quote }}
+                {{- else if .Values.components.loki.basicAuth.htpasswd }}
+                htpasswd: {{ .Values.components.loki.basicAuth.htpasswd | quote }}
+                {{- else }}
                 username: {{ required "loki.basicAuth.username is required" .Values.components.loki.basicAuth.username | quote }}
                 password: {{ required "loki.basicAuth.password is required" .Values.components.loki.basicAuth.password | quote }}
+                {{- end }}
 
             loki:
               podSecurityContext:

--- a/stable/aurora-platform/charts/aurora-mgmt/values.yaml
+++ b/stable/aurora-platform/charts/aurora-mgmt/values.yaml
@@ -421,6 +421,8 @@ components:
     basicAuth: {}
       # username:
       # password:
+      # htpasswd:
+      # existingSecret: 
 
     logStorageLocation: {}
       # storageAccountName: <storage-account-name>


### PR DESCRIPTION
Loki has a unique interaction with the ArgoCD Vault Plugin where the helm chart renders and applies the htpasswd function before AVP substitutes secrets. As a result, when trying to pull the username and password from the Key Vault and using it for basic auth, we run into an issue where instead we get something like `invalid username: loki` for Loki's NGINX gateway secret. This is due to a htpasswd function being run against the AVP placeholder, resulting in a malformed string which fails to be used for authentication. Note that this is used specifically for the password since that's what it runs against.

The fix proposed is to expand the auth methods to also include direct exposure of htpasswd so we can compute it ahead of time and pass it directly. This also includes pointing to an existing secret for a potential future situation where we can generate the secret using the htpasswd function dynamically.

