### PR TITLE
feat(grafana): Mounting certificate for external https egress

### DIFF
--- a/stable/aurora-platform/Chart.yaml
+++ b/stable/aurora-platform/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.0.242
+version: 0.0.243
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/aurora-platform/charts/aurora-core/templates/prometheus/namespace.yaml
+++ b/stable/aurora-platform/charts/aurora-core/templates/prometheus/namespace.yaml
@@ -17,7 +17,7 @@ spec:
       values: |
         # Information about the namespace.
         information:
-          # Organisational information.
+          # Organizational information.
           division: "Aurora"
           team: "Aurora Solutions"
           projectName: "Aurora Platform"
@@ -42,7 +42,8 @@ spec:
         # Configurations about the namespace.
         namespace:
         # Extra labels to add to the namespace.
-          labels: {}
+          labels:
+            namespace.ssc-spc.gc.ca/trust-manager: active
           # The type of namespace.
           # Can be one of [gateway, solution, system].
           type: "system"

--- a/stable/aurora-platform/charts/aurora-core/templates/prometheus/operator.yaml
+++ b/stable/aurora-platform/charts/aurora-core/templates/prometheus/operator.yaml
@@ -276,6 +276,12 @@ spec:
                   defaultMode: 0440
                   mountPath: /etc/secrets/auth_azuread
                   readOnly: true
+              extraConfigmapMounts
+                - name: trust-manager-propagated-custom-ca
+                  mountPath: /etc/ssl/certs/ca-certificates.crt
+                  subPath: ca-certificates.crt
+                  configMap: trust-manager-propagated-custom-ca
+                  readOnly: true
 
             kube-state-metrics:
               image: {{ default "{}" (include "prometheus.kubeStateMetrics.image" .) | nindent 16 }}


### PR DESCRIPTION
Grafana currently cannot call webhooks due to encountering x509 errors when making egress calls. This is consistent with other applications that run into the same problem due to missing the trust manager cert. This change adds in the certificate to the namespace and mounts it to the Grafana pod.