### PR TITLE
feat(alertmanager): Adding support for new msteams alerts using native power automate access

### DIFF
--- a/stable/aurora-platform/Chart.yaml
+++ b/stable/aurora-platform/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.0.250
+version: 0.0.251
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/aurora-platform/charts/aurora-core/conf/alertmanager_notification_templates/msteams-v2.tmpl
+++ b/stable/aurora-platform/charts/aurora-core/conf/alertmanager_notification_templates/msteams-v2.tmpl
@@ -1,0 +1,17 @@
+{{- define "teams.v2.title" -}}
+[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}
+{{- end -}}
+
+{{- define "teams.v2.text" -}}
+{{ range .Alerts -}}
+**Status:** {{ .Status | toUpper }}
+**Severity:** {{ .Labels.severity }}
+**Namespace:** {{ .Labels.namespace }}
+{{ if .Annotations.message }}**Message:** {{ .Annotations.message}}{{ end }}
+{{ if .Annotations.summary }}**Summary:** {{ .Annotations.summary}}{{ end }}
+{{ if .Annotations.runbook }}[Runbook]({{ .Annotations.runbook }}){{ if .Annotations.grafanaDashboard }} | {{ end }}{{ end -}}
+{{- if .Annotations.grafanaDashboard }}[Grafana]({{ .Annotations.grafanaDashboard }}){{ end }}
+---
+{{ end -}}
+{{- end -}}
+

--- a/stable/aurora-platform/charts/aurora-core/conf/alertmanager_notification_templates/msteams-v2.tmpl
+++ b/stable/aurora-platform/charts/aurora-core/conf/alertmanager_notification_templates/msteams-v2.tmpl
@@ -7,10 +7,10 @@
 **Status:** {{ .Status | toUpper }}
 **Severity:** {{ .Labels.severity }}
 **Namespace:** {{ .Labels.namespace }}
-{{ if .Annotations.message }}**Message:** {{ .Annotations.message}}{{ end }}
-{{ if .Annotations.summary }}**Summary:** {{ .Annotations.summary}}{{ end }}
-{{ if .Annotations.runbook }}[Runbook]({{ .Annotations.runbook }}){{ if .Annotations.grafanaDashboard }} | {{ end }}{{ end -}}
-{{- if .Annotations.grafanaDashboard }}[Grafana]({{ .Annotations.grafanaDashboard }}){{ end }}
+{{- if .Annotations.message }}**Message:** {{ .Annotations.message}}
+{{ end -}}
+{{- if .Annotations.summary }}**Summary:** {{ .Annotations.summary}}
+{{ end -}}
 ---
 {{ end -}}
 {{- end -}}

--- a/stable/aurora-platform/charts/aurora-core/conf/alertmanager_notification_templates/msteams-v2.tmpl
+++ b/stable/aurora-platform/charts/aurora-core/conf/alertmanager_notification_templates/msteams-v2.tmpl
@@ -7,9 +7,9 @@
 **Status:** {{ .Status | toUpper }}
 **Severity:** {{ .Labels.severity }}
 **Namespace:** {{ .Labels.namespace }}
-{{- if .Annotations.message }}**Message:** {{ .Annotations.message}}
+{{- if .Annotations.message }}**Message:** {{ .Annotations.message }}
 {{ end -}}
-{{- if .Annotations.summary }}**Summary:** {{ .Annotations.summary}}
+{{- if .Annotations.summary }}**Summary:** {{ .Annotations.summary }}
 {{ end -}}
 ---
 {{ end -}}

--- a/stable/aurora-platform/charts/aurora-core/conf/alertmanager_notification_templates/msteams-v2.tmpl
+++ b/stable/aurora-platform/charts/aurora-core/conf/alertmanager_notification_templates/msteams-v2.tmpl
@@ -7,9 +7,9 @@
 **Status:** {{ .Status | toUpper }}
 **Severity:** {{ .Labels.severity }}
 **Namespace:** {{ .Labels.namespace }}
-{{- if .Annotations.message }}**Message:** {{ .Annotations.message }}
+{{ if .Annotations.message }}**Message:** {{ .Annotations.message }}
 {{ end -}}
-{{- if .Annotations.summary }}**Summary:** {{ .Annotations.summary }}
+{{ if .Annotations.summary }}**Summary:** {{ .Annotations.summary }}
 {{ end -}}
 ---
 {{ end -}}

--- a/stable/aurora-platform/charts/aurora-core/conf/prometheus_rules/trivy/trivy_rules.yaml
+++ b/stable/aurora-platform/charts/aurora-core/conf/prometheus_rules/trivy/trivy_rules.yaml
@@ -1,0 +1,12 @@
+groups:
+- name: trivy.rules
+  rules:
+  - alert: TrivyCriticalVulnerabilitiesDetected
+    expr: 'sum by (namespace, image_repository, image_tag) (trivy_image_vulnerabilities{severity="Critical", image_registry!~"mcr\\.microsoft\\.com|.*\\.azurecr\\.io|.*\\.amazonaws\\.com|gcr\\.io"} * on (namespace) group_left() kube_namespace_labels{label_namespace_ssc_spc_gc_ca_purpose="system"}) > 0'
+    for: 5m
+    labels:
+      severity: P1-Critical
+      scope: cluster
+      teams_version: v2
+    annotations:
+      message: 'Image {{ $$labels.image_repository }}:{{ $$labels.image_tag }} has {{ $$value }} critical vulnerabilities.'

--- a/stable/aurora-platform/charts/aurora-core/templates/prometheus/_routes.tpl
+++ b/stable/aurora-platform/charts/aurora-core/templates/prometheus/_routes.tpl
@@ -2,6 +2,8 @@
 {{- range $severity, $sVal := .Values.components.prometheus.alertmanager.config.severities }}
 {{- range $environment, $matchers := $.Values.components.prometheus.alertmanager.config.environments }}
 {{- $envSeverityPair := printf "%s%s" $environment (camelcase $severity) }}
+
+# msteams v1
 - name: aurora_{{ $environment }}_{{ $severity }}
   webhook_configs:
     - url: "http://prometheus-msteams:2000/{{ $envSeverityPair }}"
@@ -10,6 +12,28 @@
   webhook_configs:
     - url: "http://prometheus-msteams:2000/{{ $envSeverityPair }}"
       send_resolved: false
+
+# msteams v2
+{{- if $.Values.components.prometheus.msteams.webhooks }}
+{{- if hasKey $.Values.components.prometheus.msteams.webhooks $envSeverityPair }}
+{{- $webhookUrl := index $.Values.components.prometheus.msteams.webhooks $envSeverityPair }}
+{{- if $webhookUrl }}
+- name: aurora_{{ $environment }}_{{ $severity }}_v2
+  msteamsv2_configs:
+    - webhook_url: {{ $webhookUrl | quote }}
+    send_resolved: true
+    title: '{{`{{ template "teams.v2.title" . }}`}}'
+    text: '{{`{{ template "teams.v2.text" . }}`}}'
+- name: aurora_{{ $environment }}_{{ $severity }}_v2_no_resolve
+  msteamsv2_configs:
+    - webhook_url: {{ $webhookUrl | quote }}
+    send_resolved: false
+    title: '{{`{{ template "teams.v2.title" . }}`}}'
+    text: '{{`{{ template "teams.v2.text" . }}`}}'
+{{- end }}
+{{- end }}
+{{- end }}
+
 {{- end }}
 {{- end }}
 {{- end }}
@@ -18,9 +42,25 @@
 {{- $severity := index . 0 -}}
 {{- $matcher := index . 1 -}}
 {{- $environment := index . 2 -}}
+{{- $root := index . 3 -}}
+{{- $envSeverityPair := printf "%s%s" $environment (camelcase $severity) -}}
 - matchers: [{{ $matcher }}]
   receiver: aurora_{{ $environment }}_{{ $severity }}
   routes:
+    {{- if $.Values.components.prometheus.msteams.webhooks }}
+    {{- if hasKey $.Values.components.prometheus.msteams.webhooks $envSeverityPair }}
+    {{- $webhookUrl := index $.Values.components.prometheus.msteams.webhooks $envSeverityPair }}
+    - matchers: ["teams_version = v2"]
+      receiver: aurora_{{ $environment }}_{{ $severity }}_v2
+      routes:
+        - matchers: ["alertname = TrivyCriticalVulnerablitiesDetected"]
+          receiver: aurora_{{ $environment }}_{{ $severity }}_v2
+          repeat_interval: 24h
+        - matchers: ["resolves = never"]
+          receiver: aurora_{{ $environment }}_{{ $severity }}_v2_no_resolve
+    {{- end }}
+    {{- end }}
+    {{- end }}
     - matchers: ["resolves = never"]
       receiver: aurora_{{ $environment }}_{{ $severity }}_no_resolve
 {{- end }}
@@ -130,7 +170,7 @@ route:
           {{- end }}
           {{- range $environment, $envRoute := $.Values.components.prometheus.alertmanager.config.environments }}
           {{- range $matcher := $envRoute.matchers }}
-{{ include "alertmanager.channel.routes" (list $severity $matcher $environment .) | indent 12 }}
+{{ include "alertmanager.channel.routes" (list $severity $matcher $environment $) | indent 12 }}
         {{- end }}
         {{- end }}
         {{- end }}
@@ -148,7 +188,7 @@ route:
           {{- end }}
           {{- range $environment, $envRoute := $.Values.components.prometheus.alertmanager.config.environments }}
           {{- range $matcher := $envRoute.matchers }}
-{{ include "alertmanager.channel.routes" (list $severity $matcher $environment .) | indent 12 }}
+{{ include "alertmanager.channel.routes" (list $severity $matcher $environment $) | indent 12 }}
         {{- end }}
         {{- end }}
         {{- end }}
@@ -166,7 +206,7 @@ route:
           {{- end }}
           {{- range $environment, $envRoute := $.Values.components.prometheus.alertmanager.config.environments }}
           {{- range $matcher := $envRoute.matchers }}
-{{ include "alertmanager.channel.routes" (list $severity $matcher $environment .) | indent 12 }}
+{{ include "alertmanager.channel.routes" (list $severity $matcher $environment $) | indent 12 }}
         {{- end }}
         {{- end }}
         {{- end }}

--- a/stable/aurora-platform/charts/aurora-core/templates/prometheus/_routes.tpl
+++ b/stable/aurora-platform/charts/aurora-core/templates/prometheus/_routes.tpl
@@ -21,15 +21,15 @@
 - name: aurora_{{ $environment }}_{{ $severity }}_v2
   msteamsv2_configs:
     - webhook_url: {{ $webhookUrl | quote }}
-    send_resolved: true
-    title: '{{`{{ template "teams.v2.title" . }}`}}'
-    text: '{{`{{ template "teams.v2.text" . }}`}}'
+      send_resolved: true
+      title: '{{`{{ template "teams.v2.title" . }}`}}'
+      text: '{{`{{ template "teams.v2.text" . }}`}}'
 - name: aurora_{{ $environment }}_{{ $severity }}_v2_no_resolve
   msteamsv2_configs:
     - webhook_url: {{ $webhookUrl | quote }}
-    send_resolved: false
-    title: '{{`{{ template "teams.v2.title" . }}`}}'
-    text: '{{`{{ template "teams.v2.text" . }}`}}'
+      send_resolved: false
+      title: '{{`{{ template "teams.v2.title" . }}`}}'
+      text: '{{`{{ template "teams.v2.text" . }}`}}'
 {{- end }}
 {{- end }}
 {{- end }}

--- a/stable/aurora-platform/charts/aurora-core/templates/prometheus/_routes.tpl
+++ b/stable/aurora-platform/charts/aurora-core/templates/prometheus/_routes.tpl
@@ -47,13 +47,14 @@
 - matchers: [{{ $matcher }}]
   receiver: aurora_{{ $environment }}_{{ $severity }}
   routes:
-    {{- if $.Values.components.prometheus.msteams.webhooks }}
-    {{- if hasKey $.Values.components.prometheus.msteams.webhooks $envSeverityPair }}
-    {{- $webhookUrl := index $.Values.components.prometheus.msteams.webhooks $envSeverityPair }}
+    {{- if $root.Values.components.prometheus.msteams.webhooks }}
+    {{- if hasKey $root.Values.components.prometheus.msteams.webhooks $envSeverityPair }}
+    {{- $webhookUrl := index $root.Values.components.prometheus.msteams.webhooks $envSeverityPair }}
+    {{- if $webhookUrl }}
     - matchers: ["teams_version = v2"]
       receiver: aurora_{{ $environment }}_{{ $severity }}_v2
       routes:
-        - matchers: ["alertname = TrivyCriticalVulnerablitiesDetected"]
+        - matchers: ["alertname = TrivyCriticalVulnerabilitiesDetected"]
           receiver: aurora_{{ $environment }}_{{ $severity }}_v2
           repeat_interval: 24h
         - matchers: ["resolves = never"]

--- a/stable/aurora-platform/charts/aurora-core/templates/prometheus/alerts.yaml
+++ b/stable/aurora-platform/charts/aurora-core/templates/prometheus/alerts.yaml
@@ -233,6 +233,22 @@ spec:
                   rules-definition: >-
                     https://github.com/gccloudone-aurora-platform-charts/-/blob/main/charts/aurora-platform/charts/aurora-core/conf/prometheus_rules/velero/velero_rules.yaml
               spec: {{ (.Files.Get "conf/prometheus_rules/velero/velero_rules.yaml")  | nindent 16 }}
+            - apiVersion: monitoring.coreos.com/v1
+              kind: PrometheusRule
+              metadata:
+                name: trivy-alerts
+                namespace: prometheus-system
+                labels:
+                  app.kubernetes.io/name: "prometheus-alerts"
+                  app.kubernetes.io/instance: "{{ .Values.global.cluster }}"
+                  app.kubernetes.io/component: monitoring
+                  app.kubernetes.io/part-of: prometheus-system
+                  app.kubernetes.io/managed-by: argo
+                  helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version }}
+                annotations:
+                  rules-definition: >-
+                    https://github.com/gccloudone-aurora-platform-charts/-/blob/main/charts/aurora-platform/charts/aurora-core/conf/prometheus_rules/trivy/trivy_rules.yaml
+              spec: {{ (.Files.Get "conf/prometheus_rules/trivy/trivy_rules.yaml")  | nindent 16 }}
   destination:
     name: {{ .Values.global.cluster }}
     namespace: platform-system

--- a/stable/aurora-platform/charts/aurora-core/templates/prometheus/manifests.yaml
+++ b/stable/aurora-platform/charts/aurora-core/templates/prometheus/manifests.yaml
@@ -48,6 +48,7 @@ spec:
                 data:
                   alertmanager.yaml: {{ include "alertmanager.config" . | b64enc }}
                   email_template.html: {{ .Files.Get "conf/alertmanager_notification_templates/email.html" | b64enc }}
+                  msteams-v2.tmpl: {{ .Files.Get "conf/alertmanager_notification_templates/msteams-v2.tmpl" | b64enc }}
                 type: Opaque
               {{- end }}
               {{- if .Values.components.prometheus.prometheus.prometheusSpec.thanos.enabled }}

--- a/stable/aurora-platform/charts/aurora-core/templates/prometheus/netpol.yaml
+++ b/stable/aurora-platform/charts/aurora-core/templates/prometheus/netpol.yaml
@@ -641,7 +641,7 @@ spec:
                     Allows Alertmanager to send alert notifications to MS Teams
                   egress:
                   - toFQDNs:
-                    - matchPattern: "**.logic.azure.com"
+                    - matchPattern: "**.api.powerplatform.com"
                     toPorts:
                     - ports:
                       - port: "443"

--- a/stable/aurora-platform/charts/aurora-core/templates/prometheus/netpol.yaml
+++ b/stable/aurora-platform/charts/aurora-core/templates/prometheus/netpol.yaml
@@ -632,6 +632,22 @@ spec:
                   endpointSelector:
                     matchLabels:
                       k8s:app: prometheus-msteams
+              - apiVersion: cilium.io/v2
+                kind: CiliumClusterwideNetworkPolicy
+                metadata:
+                  name: allow-egress-to-msteams-from-alertmanager
+                spec:
+                  description: |
+                    Allows Alertmanager to send alert notifications to MS Teams
+                  egress:
+                  - toFQDNs:
+                    - matchPattern: "**.logic.azure.com"
+                    toPorts:
+                    - ports:
+                      - port: "443"
+                  endpointSelector:
+                    matchLabels:
+                      k8s:app.kubernetes.io/name: alertmanager
               {{- end }}
               {{ if .Values.global.clusterHasLoki }}
               - apiVersion: networking.k8s.io/v1

--- a/stable/aurora-platform/charts/aurora-core/values.yaml
+++ b/stable/aurora-platform/charts/aurora-core/values.yaml
@@ -2113,6 +2113,17 @@ components:
       #  prodMajor: ""
       #  prodMinor: ""
 
+      webhooks: {}
+      #  devCritical: ""
+      #  devMajor: ""
+      #  devMinor: ""
+      #  nonProdCritical: ""
+      #  nonProdMajor: ""
+      #  nonProdMinor: ""
+      #  prodCritical: ""
+      #  prodMajor: ""
+      #  prodMinor: ""
+
   ################################
   ### Secrets Store CSI Driver ###
   ################################


### PR DESCRIPTION
This PR adds in a new option for msteams alerts to use the native power automate webhook that was added in a newer release of alertmanager. Once this update is validated, we can avoid needing dedicated pods to perform translation of alerts to msteams, reducing overhead and simplifying the alert process.

As a test, I've added in a new alert for Trivy which triggers once a day to help validate this.